### PR TITLE
Define Schema

### DIFF
--- a/config/schema/external_entities_unldirectory.storage_client.schema.yml
+++ b/config/schema/external_entities_unldirectory.storage_client.schema.yml
@@ -1,0 +1,53 @@
+plugin.plugin_configuration.external_entities_storage_client.unldirectory:
+  type: config_object
+  label: 'External entities UNL Directory storage client settings'
+  mapping:
+    endpoint:
+      type: string
+      label: 'Endpoint'
+    response_format:
+      type: string
+      label: 'Response format'
+    pager:
+      type: mapping
+      label: 'Pager'
+      mapping:
+        default_limit:
+          type: string
+          label: 'Default limit'
+        page_parameter:
+          type: string
+          label: 'Page parameter'
+        page_parameter_type:
+          type: string
+          label: 'Page parameter type'
+        page_size_parameter:
+          type: string
+          label: 'Page size parameter'
+        page_size_parameter_type:
+          type: string
+          label: 'Page size parameter type'
+    api_key:
+      type: mapping
+      label: 'API key'
+      mapping:
+        header_name:
+          type: string
+          label: 'API key header name'
+        key:
+          type: string
+          label: 'API key'
+    parameters:
+      type: mapping
+      label: 'Parameters'
+      mapping:
+        list:
+          type: sequence
+          sequence:
+            type: string
+            label: 'List parameter'
+        single:
+          type: sequence
+          sequence:
+            type: string
+            label: 'Single item parameter'


### PR DESCRIPTION
Currently, this module, which provides an External Entities plugin, does not define its schema. Configuration Inspector finds missing schema for the following:

external_entities.external_entity_type.unl_directory_entry.storage_client_config

See external_entities/config/schema/external_entities.storage_client.schema.yml for an example.