### PR TITLE
UnlDirectory::query() needs to allow for queries with no results

### DIFF
--- a/src/Plugin/ExternalEntities/StorageClient/UnlDirectory.php
+++ b/src/Plugin/ExternalEntities/StorageClient/UnlDirectory.php
@@ -97,21 +97,26 @@ class UnlDirectory extends Rest {
       $results[0] = $results_temp;
     }
 
-    foreach ($results as &$result) {
-      // Cleanup the result so that 'uid' is available at $result['uid'].
-      foreach (explode(',', $result['dn']) as $piece) {
-        $pieces = explode('=', $piece);
-        // Need to substitute hyphen in old student IDs like s-jdoe2.
-        if ($pieces[0] == 'uid' || $pieces[0] == 'CN') {
-          $pieces[0] = 'uid';
-          $pieces[1] = str_replace('-', '_', $pieces[1]);
+    if ($results) {
+      foreach ($results as &$result) {
+        // Cleanup the result so that 'uid' is available at $result['uid'].
+        foreach (explode(',', $result['dn']) as $piece) {
+          $pieces = explode('=', $piece);
+          // Need to substitute hyphen in old student IDs like s-jdoe2.
+          if ($pieces[0] == 'uid' || $pieces[0] == 'CN') {
+            $pieces[0] = 'uid';
+            $pieces[1] = str_replace('-', '_', $pieces[1]);
+          }
+          $result[$pieces[1]] = [$pieces[0] => $pieces[1]];
         }
-        $result[$pieces[1]] = [$pieces[0] => $pieces[1]];
       }
-    }
 
-    // Only return a few items in order to limit the requests in load().
-    return array_slice($results, 0, 8);
+      // Only return a few items in order to limit the requests in load().
+      return array_slice($results, 0, 8);
+    }
+    else {
+      return [];
+    }
   }
 
 }


### PR DESCRIPTION
Currently, `UnlDirectory::query()` assumes a query will return results. When there are no results, the following errors are thrown:

`
Warning: Invalid argument supplied for foreach() in Drupal\external_entities_unldirectory\Plugin\ExternalEntities\StorageClient\UnlDirectory->query() (line 100 of /var/www/html/web/modules/contrib/external_entities_unldirectory/src/Plugin/ExternalEntities/StorageClient/UnlDirectory.php)
`

`
Warning: array_slice() expects parameter 1 to be array, null given in Drupal\external_entities_unldirectory\Plugin\ExternalEntities\StorageClient\UnlDirectory->query() (line 114 of /var/www/html/web/modules/contrib/external_entities_unldirectory/src/Plugin/ExternalEntities/StorageClient/UnlDirectory.php)
`

`
Warning: Invalid argument supplied for foreach() in Drupal\external_entities\Entity\Query\External\Query->result() (line 133 of /var/www/html/web/modules/contrib/external_entities/src/Entity/Query/External/Query.php)
`

This PR seeks to account for a situation where no results are returned.