### PR TITLE
UnlDirectory::load() should catch \GuzzleHttp\Exception\ClientException exceptions

### DIFF
--- a/src/Plugin/ExternalEntities/StorageClient/UnlDirectory.php
+++ b/src/Plugin/ExternalEntities/StorageClient/UnlDirectory.php
@@ -8,6 +8,7 @@
 namespace Drupal\external_entities_unldirectory\Plugin\ExternalEntities\StorageClient;
 
 use Drupal\external_entities\Plugin\ExternalEntities\StorageClient\Rest;
+use GuzzleHttp\Exception\ClientException;
 
 /**
  * UNL Directory implementation of an external entity storage client.
@@ -31,13 +32,19 @@ class UnlDirectory extends Rest {
    */
   public function load($id) {
     $id = str_replace('_', '-', $id);
-    $response = $this->httpClient->get(
-      $this->configuration['endpoint'],
-      [
-        'query' => ['uid' => $id, 'format' => 'json'],
-        'headers' => $this->getHttpHeaders()
-      ]
-    );
+
+    try {
+      $response = $this->httpClient->get(
+        $this->configuration['endpoint'],
+        [
+          'query' => ['uid' => $id, 'format' => 'json'],
+          'headers' => $this->getHttpHeaders()
+        ]
+      );
+    }
+    catch (ClientException $e) {
+      return [];
+    }
 
     $result = $this
       ->getResponseDecoderFactory()


### PR DESCRIPTION
When `UnlDirectory::load()` receives a 404 response from UNL directory, the result is a Guzzle exception, which kills the process. This PR seeks to catch `\GuzzleHttp\Exception\ClientException` exceptions instead.

Steps to reproduce (Project Herbie)

1. Begin typing a My.UNL ID in the 'UNL Directory Reference' field on a 'Person' node add page (e.g. "cburge2")
2. Notice the console log
3. Observe the following errors in the Drupal error log:

> GuzzleHttp\Exception\ClientException: Client error: `GET https://directory.unl.edu?uid=cburger2&format=json` resulted in a `404 Cannot find that UID.` response in GuzzleHttp\Exception\RequestException::create() (line 113 of /var/www/html/vendor/guzzlehttp/guzzle/src/Exception/RequestException.php).